### PR TITLE
Update arm-none-eabi-gcc to 5-2016-q3-update.

### DIFF
--- a/arm-none-eabi-gcc.rb
+++ b/arm-none-eabi-gcc.rb
@@ -3,10 +3,10 @@ require 'formula'
 class ArmNoneEabiGcc < Formula
 
   homepage 'https://launchpad.net/gcc-arm-embedded'
-  version '5.0-2016-q2-update'
+  version '5.4-2016-q3-update'
 
-  url 'https://launchpad.net/gcc-arm-embedded/5.0/5-2016-q2-update/+download/gcc-arm-none-eabi-5_4-2016q2-20160622-mac.tar.bz2'
-  sha256 'e175a0eb7ee312013d9078a5031a14bf14dff82c7e697549f04b22e6084264c8'
+  url 'https://launchpad.net/gcc-arm-embedded/5.0/5-2016-q3-update/+download/gcc-arm-none-eabi-5_4-2016q3-20160926-mac.tar.bz2'
+  sha256 '5656cdec40f99d5c054a85bbc694276e1c4a1488cdacbbc448bc6acd3bbe070d'
 
   def install
     system 'cp', '-r', 'arm-none-eabi', 'bin', 'lib', 'share', "#{prefix}/"


### PR DESCRIPTION
Also changed version to 5.4, not 5.0.

cc @hugovincent 
