### PR TITLE
Update ARM gcc to `6-2016-q6-update`

### DIFF
--- a/arm-none-eabi-gcc.rb
+++ b/arm-none-eabi-gcc.rb
@@ -2,11 +2,11 @@ require 'formula'
 
 class ArmNoneEabiGcc < Formula
 
-  homepage 'https://launchpad.net/gcc-arm-embedded'
-  version '5-2016-q3-update'
+  homepage 'https://developer.arm.com/open-source/gnu-toolchain/gnu-rm/downloads'
+  version '6-2016-q4-update'
 
-  url 'https://launchpad.net/gcc-arm-embedded/5.0/5-2016-q3-update/+download/gcc-arm-none-eabi-5_4-2016q3-20160926-mac.tar.bz2'
-  sha256 '5656cdec40f99d5c054a85bbc694276e1c4a1488cdacbbc448bc6acd3bbe070d'
+  url 'https://developer.arm.com/-/media/Files/downloads/gnu-rm/6-2016q4/gcc-arm-none-eabi-6_2-2016q4-20161216-mac.tar.bz2'
+  sha256 'cb52433610d0084ee85abcd1ac4879303acba0b6a4ecfe5a5113c09f0ee265f0'
 
   def install
     system 'cp', '-r', 'arm-none-eabi', 'bin', 'lib', 'share', "#{prefix}/"


### PR DESCRIPTION
The precompiled download is now hosted on developer.arm.com.

cc @hugovincent 