### PR TITLE
Update prefix install to new standard

### DIFF
--- a/arm-none-eabi-gcc.rb
+++ b/arm-none-eabi-gcc.rb
@@ -9,6 +9,6 @@ class ArmNoneEabiGcc < Formula
   sha256 '7d3080514a2899d05fc55466cdc477e2448b6a62f536ffca3dd846822ff52900'
 
   def install
-    system 'cp', '-r', 'arm-none-eabi', 'bin', 'lib', 'share', "#{prefix}/"
+      prefix.install Dir["./*"]
   end
 end


### PR DESCRIPTION
`prefix.install` is preferred to `system cp`