### PR TITLE
Only install bin and share and NOT lib.

### DIFF
--- a/arm-none-eabi-gcc.rb
+++ b/arm-none-eabi-gcc.rb
@@ -9,6 +9,7 @@ class ArmNoneEabiGcc < Formula
   sha256 '7d3080514a2899d05fc55466cdc477e2448b6a62f536ffca3dd846822ff52900'
 
   def install
-    system 'cp', '-r', 'arm-none-eabi', 'bin', 'lib', 'share', "#{prefix}/"
+    bin.install Dir["bin/*"]
+    share.install Dir["share/*"]
   end
 end


### PR DESCRIPTION
This prevents libcc1.so to be symlinked into /usr/local/lib which then
may conflict with other gcc installations.

Fixes #12.