### PR TITLE
Point to gcc-arm-embedded cask

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,22 @@
-## Homebrew formulae for Arm Mbed
+# Homebrew formulae for Arm Mbed
 
-[Homebrew](https://brew.sh) is a package manager for macOS. You can use it to install [the Arm GCC toolchain](https://developer.arm.com/open-source/gnu-toolchain/gnu-rm):
+[Homebrew](https://brew.sh) is a package manager for macOS. You can use it to install the [Arm GCC toolchain](https://developer.arm.com/open-source/gnu-toolchain/gnu-rm)
+
+## Deprecation notice
+
+New versions [Arm GCC toolchain](https://developer.arm.com/open-source/gnu-toolchain/gnu-rm) are available from the [gcc-arm-embedded](https://formulae.brew.sh/cask/gcc-arm-embedded) cask, using the following instructions.
+
+```sh
+brew install --cask gcc-arm-embedded
+```
+
+## Installing from this tap
+
+If you still want to install from this tap, use the following instructions:
+
 ```sh
 brew tap ArmMbed/homebrew-formulae
 brew install arm-none-eabi-gcc
 ```
 
-We update this tap with new releases of the toolchain whenever they become available.
-
-This tap is maintained by the Arm Mbed team, not the Arm OSS compiler team! Please raise [issues with this formula here](https://github.com/ArmMbed/homebrew-formulae/issues), and [issues with the toolchain here](https://bugs.launchpad.net/gcc-arm-embedded).
+This tap was maintained by the Arm Mbed team, not the Arm OSS compiler team! Please raise [issues with this formula here](https://github.com/ArmMbed/homebrew-formulae/issues), and [issues with the toolchain here](https://bugs.launchpad.net/gcc-arm-embedded).


### PR DESCRIPTION
Homebrew now provides the [gcc-arm-embedded](https://formulae.brew.sh/cask/gcc-arm-embedded) cask.

Combined with #38, this PR recommends to use new cask, and keeps this formula for the last release on the now deprecated https://developer.arm.com/downloads/-/gnu-rm.